### PR TITLE
Add matchBase to test against file Path

### DIFF
--- a/lib/helpers/check.js
+++ b/lib/helpers/check.js
@@ -26,7 +26,7 @@ function check(files, file, pattern, def){
   }
 
   // Only process files that match the pattern (if there is a pattern)
-  if (pattern && !match(file, pattern)[0]) {
+  if (pattern && !match(file, pattern, {matchBase: true})[0]) {
     return false;
   }
 


### PR DESCRIPTION
Without ```matchBase``` option, multimatch wouldn't test against paths.