### PR TITLE
Support layout: false to override a default layout

### DIFF
--- a/lib/helpers/check.js
+++ b/lib/helpers/check.js
@@ -31,9 +31,5 @@ function check(files, file, pattern, def){
   }
 
   // Only process files with a specified layout
-  if(!data.layout && !def) {
-    return false;
-  }
-
-  return true;
+  return 'layout' in data ? data.layout : def;
 }

--- a/test/fixtures/layout-false/build/layout-false.html
+++ b/test/fixtures/layout-false/build/layout-false.html
@@ -1,0 +1,1 @@
+has no layout

--- a/test/fixtures/layout-false/expected/layout-false.html
+++ b/test/fixtures/layout-false/expected/layout-false.html
@@ -1,0 +1,1 @@
+has no layout

--- a/test/fixtures/layout-false/layouts/default.html
+++ b/test/fixtures/layout-false/layouts/default.html
@@ -1,0 +1,2 @@
+{{title}}
+{{contents}}

--- a/test/fixtures/layout-false/src/layout-false.html
+++ b/test/fixtures/layout-false/src/layout-false.html
@@ -1,0 +1,5 @@
+---
+title: Title
+layout: false
+---
+has no layout

--- a/test/index.js
+++ b/test/index.js
@@ -149,6 +149,18 @@ describe('metalsmith-layouts', function(){
       });
   });
 
+  it('should ignore files with layout: false', function(done){
+    Metalsmith('test/fixtures/layout-false')
+      .use(layouts({engine: 'handlebars', default: 'default.html'}))
+      .build(function(err){
+        if (err) {
+          return done(err);
+        }
+        equal('test/fixtures/layout-false/expected', 'test/fixtures/layout-false/build');
+        done();
+      });
+  });
+
   it('should not change file extension by default', function(done) {
     Metalsmith('test/fixtures/rename-option-default')
       .use(layouts({


### PR DESCRIPTION
This adds support for using `layout: false` in the frontmatter to override the `default` setting and not use a layout for certain files.