### PR TITLE
nunjucks template render error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -138,7 +138,8 @@ function plugin(opts){
 
       render(str, clone, function(err, str){
         if (err) {
-          return done(err);
+          console.log(err);
+          return done();
         }
 
         data.contents = new Buffer(str);


### PR DESCRIPTION
When the nunjucks engine, template render error, metalsmith can not recompile.