### PR TITLE
Allow omitting extension for layouts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -124,7 +124,10 @@ function plugin(opts){
       // Deep clone params (by passing 'true')
       var clonedParams = extend(true, {}, params);
       var clone = extend({}, clonedParams, metadata, data);
-      var str = metalsmith.path(dir, data.layout || def);
+      data.layout = data.layout || def;
+      // Add default extension if the template doesn't have one.
+      var template_name = path.extname(data.layout) ? data.layout : data.layout + params.ext;
+      var str = metalsmith.path(dir, template_name);
       var render = consolidate[engine];
 
       // Rename file if necessary
@@ -138,7 +141,7 @@ function plugin(opts){
 
       render(str, clone, function(err, str){
         if (err) {
-          return done(err);
+          return done(new Error(err));
         }
 
         data.contents = new Buffer(str);


### PR DESCRIPTION
Using an `ext` option allows to omit extensions on the layout names.