### PR TITLE
Error: Added filename to handleRenderResult.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -144,7 +144,7 @@ function plugin(opts){
        */
       var handleRenderResult = function(err, result) {
         if (err) {
-          return done(err);
+          return done(new Error('File: ' + file + ' - ' + err));
         }
 
         debug('converted file: %s', file);


### PR DESCRIPTION
Added filename to the error returned when there's a problem with `handleRenderResult`. This helps to locate the issue in the file.