### PR TITLE
Fixes "too many opened files" error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,6 +91,7 @@ function plugin(opts){
   return function(files, metalsmith, done){
     var metadata = metalsmith.metadata();
     var matches = {};
+	var templates = {};
 
     /**
      * Process any partials and pass them to consolidate as a partials object
@@ -114,7 +115,13 @@ function plugin(opts){
       debug('stringifying file: %s', file);
       var data = files[file];
       data.contents = data.contents.toString();
-      matches[file] = data;
+      var template = metalsmith.path(dir, data.layout || def);
+      if (!templates[template]) {
+        debug('found new template: %s', template);
+        templates[template] = file;
+      } else {
+        matches[file] = data;
+      }
     });
 
     /**
@@ -153,8 +160,17 @@ function plugin(opts){
     }
 
     /**
-     * Render all matched files
+     * Render all matched files.
      */
-    each(Object.keys(matches), convert, done);
+    function renderFiles(err) {
+      if (err) {
+        return done(err);
+      }
+      each(Object.keys(matches), convert, done);
+    }
+
+    // Do a first pass to load templates into the consolidate cache.
+    each(templates, convert, renderFiles);
+
   };
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,7 +91,7 @@ function plugin(opts){
   return function(files, metalsmith, done){
     var metadata = metalsmith.metadata();
     var matches = {};
-	var templates = {};
+    var templates = {};
 
     /**
      * Process any partials and pass them to consolidate as a partials object


### PR DESCRIPTION
See issue #119.
With this PR, we first compile a list of all the layout templates that our input files need. We then do a first pass of renders that treats one input file for each of these templates, so that consolidate will load all the templates into its cache. Then, once the templates are all cached, we run through the rest of the input files.