### PR TITLE
Add custom error message to include file path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -148,6 +148,8 @@ function plugin(opts){
 
       render(str, clone, function(err, str){
         if (err) {
+          err.message = "Error rendering template `" + data.layout + "` for file `"
+            + file + "`. " + err;
           return done(err);
         }
 


### PR DESCRIPTION
This leads to errors like

```
Error rendering template `content.html` for file `styleguide/text-media.html`: Error: Parse error on line 102:
...      {{#if headline)}}      <div class
-----------------------^
Expecting 'CLOSE', 'OPEN_SEXPR', 'ID', 'OPEN_BLOCK_PARAMS', 'STRING', 'NUMBER', 'BOOLEAN', 'UNDEFINED', 'NULL', 'DATA', got 'CLOSE_SEXPR'
```