### PR TITLE
fix `assert.rejects` usage in tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -196,13 +196,11 @@ describe('@metalsmith/layouts', () => {
 
   it('should return an error for an invalid pattern', async () => {
     const { dir } = fixture('invalid-pattern')
-    rejects(
-      async () => {
-        await Metalsmith(dir)
-          .env('DEBUG', process.env.DEBUG)
-          .use(plugin({ pattern: () => {} }))
-          .build()
-      },
+    await rejects(
+      Metalsmith(dir)
+        .env('DEBUG', process.env.DEBUG)
+        .use(plugin({ transform: 'handlebars', pattern: () => {} }))
+        .build(),
       { message: 'invalid pattern, the pattern option should be a string or array of strings.' }
     )
   })


### PR DESCRIPTION
`assert.rejects` needs to be awaited inside of the async test body.
 If it is not, the test is effectively ignored since any exceptions are thrown after the test function completes.

other changes:
- `transform` option is required by the plugin
- wrapping a Promise returned by `Metalsmith` invocation is not necessary: `assert.rejects` takes a Promise as first argument

see:
https://nodejs.org/api/assert.html#assertrejectsasyncfn-error-message