### PR TITLE
add support for preserving the filename by extending the semantics of the `extname` option

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -18,8 +18,9 @@ export function parseFilepath(filename) {
  * @returns {string}
  */
 export function handleExtname(filename, extname) {
+  if (typeof extname !== "string") return filename
   const { dirname, base, extensions } = parseFilepath(filename)
-  const e = extname && extname.slice(1)
+  const e = extname.length > 1 ? extname.slice(1) : false
 
   if (!e || e !== extensions[extensions.length - 1]) {
     extensions.pop()

--- a/test/index.js
+++ b/test/index.js
@@ -269,10 +269,12 @@ describe('@metalsmith/layouts', () => {
       strictEqual(handleExtname('index.html', options.defaults.extname), 'index.html')
       strictEqual(handleExtname('index.htm', '.htm'), 'index.htm')
     })
-    it("removes the extension if options.extname === null|false|''", () => {
-      strictEqual(handleExtname('index.njk', false), 'index')
+    it("removes the extension if options.extname === ''", () => {
       strictEqual(handleExtname('index.njk', ''), 'index')
-      strictEqual(handleExtname('index.njk', null), 'index')
+    })
+    it("keeps the extension if options.extname === null|false", () => {
+      strictEqual(handleExtname('index.xml', false), 'index.xml')
+      strictEqual(handleExtname('index.xml', null), 'index.xml')
     })
   })
 })


### PR DESCRIPTION
currently the module offers only 2 options when handling filename
- overwrite extension when extensions is specified
- remove the extension when extname is falsy

This does not give the user an easy option to preserve the existing extension - for example when layouts is used to generate both `.html` and `.xml` files.

this change treats null|false value as _do not touch my filename_ while preserving empty string value as _remove the extension_

I am open to other suggestions on how to implement _do not modify filename_ functionality while maintaining backwards compatibility: using `extname === true`, adding a new option?